### PR TITLE
CI: Fix clang build for lunaa

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -155,8 +155,8 @@ jobs:
         repo sync --no-tags --no-clone-bundle -j$(nproc --all)
     - name: Sync Clang
       run: |
-        mkdir -p prebuilts-master/clang/host/linux-x86/clang-r416183b/
-        cd prebuilts-master/clang/host/linux-x86/clang-r416183b/
+        mkdir -p prebuilts-master/clang/host/linux-x86/clang-r450784d/
+        cd prebuilts-master/clang/host/linux-x86/clang-r450784d/
         curl -LO "https://raw.githubusercontent.com/Neutron-Toolchains/antman/main/antman"
         bash antman -S=latest
         bash antman --patch=glibc


### PR DESCRIPTION
https://github.com/mvaisakh/oneplus9pro/actions/runs/4479701315/jobs/7873996455#step:5:770

It is caused by the wrong clang directory.