### PR TITLE
Revert "drivers/qcacld-3.0: disable fw-log by default"

### DIFF
--- a/drivers/staging/qcacld-3.0/core/hdd/src/wlan_hdd_main.c
+++ b/drivers/staging/qcacld-3.0/core/hdd/src/wlan_hdd_main.c
@@ -12768,7 +12768,7 @@ static void hdd_cfg_params_init(struct hdd_context *hdd_ctx)
 
 	config->private_wext_control = cfg_get(psoc, CFG_PRIVATE_WEXT_CONTROL);
 	config->enablefwprint = cfg_get(psoc, CFG_ENABLE_FW_UART_PRINT);
-	config->enable_fw_log = cfg_get(psoc, 0);
+	config->enable_fw_log = cfg_get(psoc, CFG_ENABLE_FW_LOG);
 	config->operating_chan_freq = cfg_get(psoc, CFG_OPERATING_FREQUENCY);
 	config->num_vdevs = cfg_get(psoc, CFG_NUM_VDEV_ENABLE);
 	qdf_str_lcopy(config->enable_concurrent_sta,


### PR DESCRIPTION
This reverts commit a2bbea61177c6f3054bece17e9afe3de9869e076.