### PR TITLE
drivers: crypto: qcedev: Silence heavy logspam

### DIFF
--- a/drivers/crypto/msm/qcedev.c
+++ b/drivers/crypto/msm/qcedev.c
@@ -1936,7 +1936,7 @@ long qcedev_ioctl(struct file *file,
 					goto exit_free_qcedev_areq;
 				}
 				map_buf.buf_vaddr[i] = vaddr;
-				pr_info("%s: info: vaddr = %llx\n",
+				pr_debug("%s: info: vaddr = %llx\n",
 					__func__, vaddr);
 			}
 


### PR DESCRIPTION
 * qcedev_ioctl spams dmesg insanely during certain activities such as widevine L1 playback (netflix/prime video etc.)