### PR TITLE
power: oplus: Enable OTG irrespective of otg_switch status

### DIFF
--- a/drivers/power/oplus/charger_ic/oplus_battery_sm8350.c
+++ b/drivers/power/oplus/charger_ic/oplus_battery_sm8350.c
@@ -7088,12 +7088,7 @@ int oplus_set_otg_switch_status(bool enable)
 		return rc;
 	}
 
-	chip->otg_switch = !!enable;
-	if (enable) {
-		oplus_ccdetect_enable();
-	} else {
-		oplus_ccdetect_disable();
-	}
+	oplus_ccdetect_enable();
 	printk(KERN_ERR "[OPLUS_CHG][%s]: otg_switch=%d, otg_online=%d\n",
 		__func__, chip->otg_switch, chip->otg_online);
 


### PR DESCRIPTION
on boot
In system : wait for '/sys/class/oplus_chg/usb/otg_switch' took 896ms In recovery : it takes >5 seconds for the node to become available. So enable it here to avoid possible situations where init might attempt writing to a non-existent node.

Change-Id: I92ec6db5bf83865c356061ee73d5899cc834b00f