### PR TITLE
build.config.common*: Fix typos

### DIFF
--- a/build.config.common
+++ b/build.config.common
@@ -9,7 +9,7 @@ MKDTBO_EXT=${ROOT_DIR}/tools/libufdt/utils/src/mkdtboimg.py
 
 KCFLAGS="${KCFLAGS} -D__ANDROID_COMMON_KERNEL__"
 STOP_SHIP_TRACEPRINTK=1
-if ![ ${VARIANT} == ngki ]; then
+if ! [ ${VARIANT} == ngki ]; then
 IN_KERNEL_MODULES=1
 fi
 DO_NOT_STRIP_MODULES=0

--- a/build.config.common.gcc
+++ b/build.config.common.gcc
@@ -7,7 +7,7 @@ MKDTBO_EXT=${ROOT_DIR}/tools/libufdt/utils/src/mkdtboimg.py
 
 KCFLAGS="${KCFLAGS} -D__ANDROID_COMMON_KERNEL__"
 STOP_SHIP_TRACEPRINTK=1
-if ![ ${VARIANT} == ngki ]; then
+if ! [ ${VARIANT} == ngki ]; then
 IN_KERNEL_MODULES=1
 fi
 DO_NOT_STRIP_MODULES=1


### PR DESCRIPTION
It causes `kernel/msm-5.4/build.config.common: line 12: ![: command not found`.  https://github.com/mvaisakh/oneplus9pro/actions/runs/4678526216/jobs/8287364871#step:5:12