### PR TITLE
scripts/dtc: Update to upstream version v1.7.0-19-g2cdf93a

### DIFF
--- a/scripts/dtc/dtc.h
+++ b/scripts/dtc/dtc.h
@@ -260,16 +260,16 @@ struct node {
 void add_label(struct label **labels, char *label);
 void delete_labels(struct label **labels);
 
-struct property *build_property(char *name, struct data val,
+struct property *build_property(const char *name, struct data val,
 				struct srcpos *srcpos);
-struct property *build_property_delete(char *name);
+struct property *build_property_delete(const char *name);
 struct property *chain_property(struct property *first, struct property *list);
 struct property *reverse_properties(struct property *first);
 
 struct node *build_node(struct property *proplist, struct node *children,
 			struct srcpos *srcpos);
 struct node *build_node_delete(struct srcpos *srcpos);
-struct node *name_node(struct node *node, char *name);
+struct node *name_node(struct node *node, const char *name);
 struct node *omit_node_if_unused(struct node *node);
 struct node *reference_node(struct node *node);
 struct node *chain_node(struct node *first, struct node *list);
@@ -336,9 +336,9 @@ struct dt_info *build_dt_info(unsigned int dtsflags,
 			      struct reserve_info *reservelist,
 			      struct node *tree, uint32_t boot_cpuid_phys);
 void sort_tree(struct dt_info *dti);
-void generate_label_tree(struct dt_info *dti, char *name, bool allocph);
-void generate_fixups_tree(struct dt_info *dti, char *name);
-void generate_local_fixups_tree(struct dt_info *dti, char *name);
+void generate_label_tree(struct dt_info *dti, const char *name, bool allocph);
+void generate_fixups_tree(struct dt_info *dti, const char *name);
+void generate_local_fixups_tree(struct dt_info *dti, const char *name);
 
 /* Checks */
 

--- a/scripts/dtc/fstree.c
+++ b/scripts/dtc/fstree.c
@@ -43,7 +43,7 @@ static struct node *read_fstree(const char *dirname)
 					"WARNING: Cannot open %s: %s\n",
 					tmpname, strerror(errno));
 			} else {
-				prop = build_property(xstrdup(de->d_name),
+				prop = build_property(de->d_name,
 						      data_copy_file(pfile,
 								     st.st_size),
 						      NULL);

--- a/scripts/dtc/libfdt/fdt.h
+++ b/scripts/dtc/libfdt/fdt.h
@@ -35,14 +35,14 @@ struct fdt_reserve_entry {
 
 struct fdt_node_header {
 	fdt32_t tag;
-	char name[0];
+	char name[];
 };
 
 struct fdt_property {
 	fdt32_t tag;
 	fdt32_t len;
 	fdt32_t nameoff;
-	char data[0];
+	char data[];
 };
 
 #endif /* !__ASSEMBLY */

--- a/scripts/dtc/libfdt/libfdt.h
+++ b/scripts/dtc/libfdt/libfdt.h
@@ -660,6 +660,13 @@ int fdt_next_property_offset(const void *fdt, int offset);
 const struct fdt_property *fdt_get_property_by_offset(const void *fdt,
 						      int offset,
 						      int *lenp);
+static inline struct fdt_property *fdt_get_property_by_offset_w(void *fdt,
+								int offset,
+								int *lenp)
+{
+	return (struct fdt_property *)(uintptr_t)
+		fdt_get_property_by_offset(fdt, offset, lenp);
+}
 
 /**
  * fdt_get_property_namelen - find a property based on substring

--- a/scripts/dtc/livetree.c
+++ b/scripts/dtc/livetree.c
@@ -36,27 +36,27 @@ void delete_labels(struct label **labels)
 		label->deleted = 1;
 }
 
-struct property *build_property(char *name, struct data val,
+struct property *build_property(const char *name, struct data val,
 				struct srcpos *srcpos)
 {
 	struct property *new = xmalloc(sizeof(*new));
 
 	memset(new, 0, sizeof(*new));
 
-	new->name = name;
+	new->name = xstrdup(name);
 	new->val = val;
 	new->srcpos = srcpos_copy(srcpos);
 
 	return new;
 }
 
-struct property *build_property_delete(char *name)
+struct property *build_property_delete(const char *name)
 {
 	struct property *new = xmalloc(sizeof(*new));
 
 	memset(new, 0, sizeof(*new));
 
-	new->name = name;
+	new->name = xstrdup(name);
 	new->deleted = 1;
 
 	return new;
@@ -116,11 +116,11 @@ struct node *build_node_delete(struct srcpos *srcpos)
 	return new;
 }
 
-struct node *name_node(struct node *node, char *name)
+struct node *name_node(struct node *node, const char *name)
 {
 	assert(node->name == NULL);
 
-	node->name = name;
+	node->name = xstrdup(name);
 
 	return node;
 }
@@ -250,6 +250,7 @@ struct node * add_orphan_node(struct node *dt, struct node *new_node, char *ref)
 	name_node(new_node, "__overlay__");
 	node = build_node(p, new_node, NULL);
 	name_node(node, name);
+	free(name);
 
 	add_child(dt, node);
 	return dt;
@@ -616,10 +617,25 @@ struct node *get_node_by_ref(struct node *tree, const char *ref)
 	return target;
 }
 
+static void add_phandle_property(struct node *node,
+				 const char *name, int format)
+{
+	struct data d;
+
+	if (!(phandle_format & format))
+		return;
+	if (get_property(node, name))
+		return;
+
+	d = data_add_marker(empty_data, TYPE_UINT32, NULL);
+	d = data_append_cell(d, node->phandle);
+
+	add_property(node, build_property(name, d, NULL));
+}
+
 cell_t get_node_phandle(struct node *root, struct node *node)
 {
 	static cell_t phandle = 1; /* FIXME: ick, static local */
-	struct data d = empty_data;
 
 	if (phandle_is_valid(node->phandle))
 		return node->phandle;
@@ -629,16 +645,8 @@ cell_t get_node_phandle(struct node *root, struct node *node)
 
 	node->phandle = phandle;
 
-	d = data_add_marker(d, TYPE_UINT32, NULL);
-	d = data_append_cell(d, phandle);
-
-	if (!get_property(node, "linux,phandle")
-	    && (phandle_format & PHANDLE_LEGACY))
-		add_property(node, build_property("linux,phandle", d, NULL));
-
-	if (!get_property(node, "phandle")
-	    && (phandle_format & PHANDLE_EPAPR))
-		add_property(node, build_property("phandle", d, NULL));
+	add_phandle_property(node, "linux,phandle", PHANDLE_LEGACY);
+	add_phandle_property(node, "phandle", PHANDLE_EPAPR);
 
 	/* If the node *does* have a phandle property, we must
 	 * be dealing with a self-referencing phandle, which will be
@@ -808,18 +816,18 @@ void sort_tree(struct dt_info *dti)
 }
 
 /* utility helper to avoid code duplication */
-static struct node *build_and_name_child_node(struct node *parent, char *name)
+static struct node *build_and_name_child_node(struct node *parent, const char *name)
 {
 	struct node *node;
 
 	node = build_node(NULL, NULL, NULL);
-	name_node(node, xstrdup(name));
+	name_node(node, name);
 	add_child(parent, node);
 
 	return node;
 }
 
-static struct node *build_root_node(struct node *dt, char *name)
+static struct node *build_root_node(struct node *dt, const char *name)
 {
 	struct node *an;
 
@@ -918,6 +926,12 @@ static void add_fixup_entry(struct dt_info *dti, struct node *fn,
 
 	/* m->ref can only be a REF_PHANDLE, but check anyway */
 	assert(m->type == REF_PHANDLE);
+
+	/* The format only permits fixups for references to label, not
+	 * references to path */
+	if (strchr(m->ref, '/'))
+		die("Can't generate fixup for reference to path &{%s}\n",
+		    m->ref);
 
 	/* there shouldn't be any ':' in the arguments */
 	if (strchr(node->fullpath, ':') || strchr(prop->name, ':'))
@@ -1034,7 +1048,7 @@ static void generate_local_fixups_tree_internal(struct dt_info *dti,
 		generate_local_fixups_tree_internal(dti, lfn, c);
 }
 
-void generate_label_tree(struct dt_info *dti, char *name, bool allocph)
+void generate_label_tree(struct dt_info *dti, const char *name, bool allocph)
 {
 	if (!any_label_tree(dti, dti->dt))
 		return;
@@ -1042,7 +1056,7 @@ void generate_label_tree(struct dt_info *dti, char *name, bool allocph)
 				     dti->dt, allocph);
 }
 
-void generate_fixups_tree(struct dt_info *dti, char *name)
+void generate_fixups_tree(struct dt_info *dti, const char *name)
 {
 	if (!any_fixup_tree(dti, dti->dt))
 		return;
@@ -1050,7 +1064,7 @@ void generate_fixups_tree(struct dt_info *dti, char *name)
 				      dti->dt);
 }
 
-void generate_local_fixups_tree(struct dt_info *dti, char *name)
+void generate_local_fixups_tree(struct dt_info *dti, const char *name)
 {
 	if (!any_local_fixup_tree(dti, dti->dt))
 		return;

--- a/scripts/dtc/srcpos.c
+++ b/scripts/dtc/srcpos.c
@@ -3,7 +3,9 @@
  * Copyright 2007 Jon Loeliger, Freescale Semiconductor, Inc.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <stdio.h>
 
@@ -311,8 +313,8 @@ srcpos_string(struct srcpos *pos)
 static char *
 srcpos_string_comment(struct srcpos *pos, bool first_line, int level)
 {
-	char *pos_str, *fname, *first, *rest;
-	bool fresh_fname = false;
+	char *pos_str, *fresh_fname = NULL, *first, *rest;
+	const char *fname;
 
 	if (!pos) {
 		if (level > 1) {
@@ -330,9 +332,9 @@ srcpos_string_comment(struct srcpos *pos, bool first_line, int level)
 	else if (level > 1)
 		fname = pos->file->name;
 	else {
-		fname = shorten_to_initial_path(pos->file->name);
-		if (fname)
-			fresh_fname = true;
+		fresh_fname = shorten_to_initial_path(pos->file->name);
+		if (fresh_fname)
+			fname = fresh_fname;
 		else
 			fname = pos->file->name;
 	}
@@ -346,7 +348,7 @@ srcpos_string_comment(struct srcpos *pos, bool first_line, int level)
 			  first_line ? pos->first_line : pos->last_line);
 
 	if (fresh_fname)
-		free(fname);
+		free(fresh_fname);
 
 	if (pos->next != NULL) {
 		rest = srcpos_string_comment(pos->next, first_line, level);

--- a/scripts/dtc/util.h
+++ b/scripts/dtc/util.h
@@ -65,7 +65,7 @@ extern char *xstrndup(const char *s, size_t len);
 
 extern int PRINTF(2, 3) xasprintf(char **strp, const char *fmt, ...);
 extern int PRINTF(2, 3) xasprintf_append(char **strp, const char *fmt, ...);
-extern int xavsprintf_append(char **strp, const char *fmt, va_list ap);
+extern int PRINTF(2, 0) xavsprintf_append(char **strp, const char *fmt, va_list ap);
 extern char *join_path(const char *path, const char *name);
 
 /**

--- a/scripts/dtc/version_gen.h
+++ b/scripts/dtc/version_gen.h
@@ -1,1 +1,1 @@
-#define DTC_VERSION "DTC 1.6.1-ged310803-dirty"
+#define DTC_VERSION "DTC 1.7.0-g2cdf93a6"

--- a/scripts/dtc/yamltree.c
+++ b/scripts/dtc/yamltree.c
@@ -10,7 +10,7 @@
 #include "dtc.h"
 #include "srcpos.h"
 
-char *yaml_error_name[] = {
+const char *yaml_error_name[] = {
 	[YAML_NO_ERROR] = "no error",
 	[YAML_MEMORY_ERROR] = "memory error",
 	[YAML_READER_ERROR] = "reader error",
@@ -33,7 +33,7 @@ static void yaml_propval_int(yaml_emitter_t *emitter, struct marker *markers,
 	char *data, unsigned int seq_offset, unsigned int len, int width)
 {
 	yaml_event_t event;
-	void *tag;
+	const void *tag;
 	unsigned int off;
 
 	switch(width) {
@@ -47,7 +47,7 @@ static void yaml_propval_int(yaml_emitter_t *emitter, struct marker *markers,
 	assert(len % width == 0);
 
 	yaml_sequence_start_event_initialize(&event, NULL,
-		(yaml_char_t *)tag, width == 4, YAML_FLOW_SEQUENCE_STYLE);
+		(const yaml_char_t *)tag, width == 4, YAML_FLOW_SEQUENCE_STYLE);
 	yaml_emitter_emit_or_die(emitter, &event);
 
 	for (off = 0; off < len; off += width) {
@@ -80,11 +80,11 @@ static void yaml_propval_int(yaml_emitter_t *emitter, struct marker *markers,
 
 		if (is_phandle)
 			yaml_scalar_event_initialize(&event, NULL,
-				(yaml_char_t*)"!phandle", (yaml_char_t *)buf,
+				(const yaml_char_t*)"!phandle", (const yaml_char_t *)buf,
 				strlen(buf), 0, 0, YAML_PLAIN_SCALAR_STYLE);
 		else
 			yaml_scalar_event_initialize(&event, NULL,
-				(yaml_char_t*)YAML_INT_TAG, (yaml_char_t *)buf,
+				(const yaml_char_t*)YAML_INT_TAG, (const yaml_char_t *)buf,
 				strlen(buf), 1, 1, YAML_PLAIN_SCALAR_STYLE);
 		yaml_emitter_emit_or_die(emitter, &event);
 	}
@@ -105,7 +105,7 @@ static void yaml_propval_string(yaml_emitter_t *emitter, char *str, int len)
 		assert(isascii(str[i]));
 
 	yaml_scalar_event_initialize(&event, NULL,
-		(yaml_char_t *)YAML_STR_TAG, (yaml_char_t*)str,
+		(const yaml_char_t *)YAML_STR_TAG, (const yaml_char_t*)str,
 		len-1, 0, 1, YAML_DOUBLE_QUOTED_SCALAR_STYLE);
 	yaml_emitter_emit_or_die(emitter, &event);
 }
@@ -119,15 +119,15 @@ static void yaml_propval(yaml_emitter_t *emitter, struct property *prop)
 
 	/* Emit the property name */
 	yaml_scalar_event_initialize(&event, NULL,
-		(yaml_char_t *)YAML_STR_TAG, (yaml_char_t*)prop->name,
+		(const yaml_char_t *)YAML_STR_TAG, (const yaml_char_t*)prop->name,
 		strlen(prop->name), 1, 1, YAML_PLAIN_SCALAR_STYLE);
 	yaml_emitter_emit_or_die(emitter, &event);
 
 	/* Boolean properties are easiest to deal with. Length is zero, so just emit 'true' */
 	if (len == 0) {
 		yaml_scalar_event_initialize(&event, NULL,
-			(yaml_char_t *)YAML_BOOL_TAG,
-			(yaml_char_t*)"true",
+			(const yaml_char_t *)YAML_BOOL_TAG,
+			(const yaml_char_t*)"true",
 			strlen("true"), 1, 0, YAML_PLAIN_SCALAR_STYLE);
 		yaml_emitter_emit_or_die(emitter, &event);
 		return;
@@ -137,7 +137,7 @@ static void yaml_propval(yaml_emitter_t *emitter, struct property *prop)
 		die("No markers present in property '%s' value\n", prop->name);
 
 	yaml_sequence_start_event_initialize(&event, NULL,
-		(yaml_char_t *)YAML_SEQ_TAG, 1, YAML_FLOW_SEQUENCE_STYLE);
+		(const yaml_char_t *)YAML_SEQ_TAG, 1, YAML_FLOW_SEQUENCE_STYLE);
 	yaml_emitter_emit_or_die(emitter, &event);
 
 	for_each_marker(m) {
@@ -185,7 +185,7 @@ static void yaml_tree(struct node *tree, yaml_emitter_t *emitter)
 		return;
 
 	yaml_mapping_start_event_initialize(&event, NULL,
-		(yaml_char_t *)YAML_MAP_TAG, 1, YAML_ANY_MAPPING_STYLE);
+		(const yaml_char_t *)YAML_MAP_TAG, 1, YAML_ANY_MAPPING_STYLE);
 	yaml_emitter_emit_or_die(emitter, &event);
 
 	for_each_property(tree, prop)
@@ -194,7 +194,7 @@ static void yaml_tree(struct node *tree, yaml_emitter_t *emitter)
 	/* Loop over all the children, emitting them into the map */
 	for_each_child(tree, child) {
 		yaml_scalar_event_initialize(&event, NULL,
-			(yaml_char_t *)YAML_STR_TAG, (yaml_char_t*)child->name,
+			(const yaml_char_t *)YAML_STR_TAG, (const yaml_char_t*)child->name,
 			strlen(child->name), 1, 0, YAML_PLAIN_SCALAR_STYLE);
 		yaml_emitter_emit_or_die(emitter, &event);
 		yaml_tree(child, emitter);
@@ -217,7 +217,7 @@ void dt_to_yaml(FILE *f, struct dt_info *dti)
 	yaml_document_start_event_initialize(&event, NULL, NULL, NULL, 0);
 	yaml_emitter_emit_or_die(&emitter, &event);
 
-	yaml_sequence_start_event_initialize(&event, NULL, (yaml_char_t *)YAML_SEQ_TAG, 1, YAML_ANY_SEQUENCE_STYLE);
+	yaml_sequence_start_event_initialize(&event, NULL, (const yaml_char_t *)YAML_SEQ_TAG, 1, YAML_ANY_SEQUENCE_STYLE);
 	yaml_emitter_emit_or_die(&emitter, &event);
 
 	yaml_tree(dti->dt, &emitter);


### PR DESCRIPTION
This adds the following commits from upstream:

2cdf93a fdtoverlay: Fix usage string to not mention "<type>" 72fc810 build-sys: add -Wwrite-strings
083ab26 tests: fix leaks spotted by ASAN
6f8b28f livetree: fix leak spotted by ASAN
fd68bb8 Make name_node() xstrdup its name argument 4718189 Delay xstrdup() of node and property names coming from a flat tree 0b842c3 Make build_property() xstrdup its name argument 9cceabe checks: correct I2C 10-bit address check
0d56145 yamltree.c: fix -Werror=discarded-qualifiers & -Werror=cast-qual 61fa22b checks: make check.data const
7a1d72a checks.c: fix check_msg() leak
ee57999 checks.c: fix heap-buffer-overflow
44c9b73 tests: fix -Wwrite-strings
5b60f51 srcpos.c: fix -Wwrite-strings
32174a6 meson: Fix cell overflow tests when running from meson 64a907f meson.build: bump version to 1.7.0
e3cde06 Add -Wsuggest-attribute=format warning, correct warnings thus generated 4182182 Use #ifdef NO_VALGRIND
71c19f2 Do not redefine _GNU_SOURCE if already set 039a994 Bump version to v1.7.0
9b62ec8 Merge remote-tracking branch 'gitlab/main' 3f29d6d pylibfdt: add size_hint parameter for get_path 2022bb1 checks: Update #{size,address}-cells check for 'dma-ranges' abbd523 pylibfdt: Work-around SWIG limitations with flexible arrays a41509b libfdt: Replace deprecated 0-length arrays with proper flexible arrays 2cd89f8 dtc: Warning rather than error on possible truncation of cell values 55778a0 libfdt: tests: add get_next_tag_invalid_prop_len 7359034 libfdt: prevent integer overflow in fdt_next_tag 035fb90 libfdt: add fdt_get_property_by_offset_w helper 98a0700 Makefile: fix infinite recursion by dropping non-existent `%.output` a036cc7 Makefile: limit make re-execution to avoid infinite spin c6e9210 libdtc: remove duplicate judgments
e37c256 Don't generate erroneous fixups from reference to path 5045465 libfdt: Don't mask fdt_get_name() returned error e64a204 manual.txt: Follow README.md and remove Jon f508c83 Update README in MANIFEST.in and setup.py to README.md c2ccf8a Add description of Signed-off-by lines
90b9d9d Split out information for contributors to CONTRIBUTING.md 0ee1d47 Remove Jon Loeliger from maintainers list
b33a73c Convert README to README.md
7ad6073 Allow static building with meson
fd9b8c9 Allow static building with make
fda71da libfdt: Handle failed get_name() on BEGIN_NODE c7c7f17 Fix test script to run also on dash shell
01f23ff Add missing relref_merge test to meson test list